### PR TITLE
Serialize request body before passing it to gRPC client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/conductor-poller/conductor-polling.js
+++ b/conductor-poller/conductor-polling.js
@@ -150,7 +150,7 @@ export const registerHttpWorker = async () => conductorClient.registerWatcher(
                 input.cookies,
             );
 
-            sendGrpcRequest(httpOptions, input.body,
+            sendGrpcRequest(httpOptions, JSON.parse(input.body),
                 async (err, grpcResponse) => {
                     if (err != null) {
                         logger.warn('Error while sending grpc request', err);

--- a/conductor-poller/conductor-polling.js
+++ b/conductor-poller/conductor-polling.js
@@ -149,8 +149,13 @@ export const registerHttpWorker = async () => conductorClient.registerWatcher(
                 input.contentType,
                 input.cookies,
             );
-
-            sendGrpcRequest(httpOptions, JSON.parse(input.body),
+            let body = input.body;
+            try {
+                body = JSON.parse(body);
+            }catch {
+                // not a valid json, use default string value
+            }
+            sendGrpcRequest(httpOptions, body,
                 async (err, grpcResponse) => {
                     if (err != null) {
                         logger.warn('Error while sending grpc request', err);


### PR DESCRIPTION
When body is a JSON object, e.g. {"query":"..."}, it must be serialized
to string. Otherwise it will be transformed to something like
'[Object object]' .